### PR TITLE
Use ASCIISet

### DIFF
--- a/dxcc/init.go
+++ b/dxcc/init.go
@@ -2,12 +2,14 @@ package dxcc
 
 import (
 	"encoding/csv"
-	"github.com/pkg/errors"
 	"io"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/elliotwutingfeng/asciiset"
+	"github.com/pkg/errors"
 )
 
 type Entities []Entity
@@ -93,20 +95,21 @@ func splitPrefixes(pfx string) []string {
 
 func prefixRegexp(pfx string) string {
 
-	initialChars := map[byte]struct{}{}
+	initialChars, _ := asciiset.MakeASCIISet("")
 	pfx = strings.Replace(pfx, ";", "", -1)
 	for _, p := range strings.Split(pfx, " ") {
 		switch p[0] {
 		case '=':
-			initialChars[p[1]] = struct{}{}
+			initialChars.Add(p[1])
 		default:
-			initialChars[p[0]] = struct{}{}
+			initialChars.Add(p[0])
 		}
 	}
 	sorted := []byte{}
-	for c := range initialChars {
+	initialChars.Visit(func(c byte) bool {
 		sorted = append(sorted, c)
-	}
+		return false
+	})
 	sort.Slice(sorted, func(i, j int) bool {
 		return sorted[i] < sorted[j]
 	})

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/dustin/go-humanize v1.0.0
+	github.com/elliotwutingfeng/asciiset v0.0.0-20230602010337-0d6afe084374
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/rwestlund/gotex v0.0.0-20170412080108-3c68d9bfff3b

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/elliotwutingfeng/asciiset v0.0.0-20230602010337-0d6afe084374 h1:lCH/+UJA4MW++OVrk0THIS/jXTwn++CLYvKFmPeS8xY=
+github.com/elliotwutingfeng/asciiset v0.0.0-20230602010337-0d6afe084374/go.mod h1:GLo/8fDswSAniFG+BFIaiSPcK610jyzgEhWYPQwuQdw=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=


### PR DESCRIPTION
Proposing use of `ASCIISet` instead of `map[byte]struct{}`.

`ASCIISet` is a zero-dependency library for sets of ASCII characters with [28 times faster lookup speed](https://github.com/elliotwutingfeng/asciiset#results) than `map[byte]struct{}`.